### PR TITLE
fix(user): fix message count display in UserHistory page

### DIFF
--- a/src/pages/UserHistory.js
+++ b/src/pages/UserHistory.js
@@ -871,7 +871,7 @@ const UserHistory = () => {
           <Card>
             <CardHeader>
               <CardTitle>메시지 목록</CardTitle>
-              <Badge>{filteredMessages.length}건</Badge>
+              <Badge>{totalCount}건</Badge>
             </CardHeader>
             <CardBody>
               <MessagesGrid>


### PR DESCRIPTION
# Fix message count display in UserHistory page

## 📝 Summary
UserHistory 페이지에서 메시지 카운트가 페이지네이션된 메시지 개수(최대 12개)만 표시되는 버그를 수정했습니다. 이제 전체 필터링된 메시지 개수를 정확하게 표시합니다.

## 🔗 Related Issue
Closes #39

## 🐛 Problem
- 현재 Badge에 `filteredMessages.length`를 사용하여 현재 페이지의 메시지 개수만 표시
- 전체 필터링된 메시지가 50개여도 "12건"으로 표시됨
- 사용자가 실제 전체 메시지 개수를 알 수 없음

## 🛠️ Changes
**파일**: `src/pages/UserHistory.js` (line 874)

**변경 내용**:
```diff
  <CardHeader>
    <CardTitle>메시지 목록</CardTitle>
-   <Badge>{filteredMessages.length}건</Badge>
+   <Badge>{totalCount}건</Badge>
  </CardHeader>
```

## 💡 Solution
기존에 `applyFiltersAndPagination` 함수에서 이미 `totalCount` state에 전체 필터링된 메시지 개수(`filtered.length`)를 저장하고 있었습니다. Badge에서 `filteredMessages.length` 대신 `totalCount`를 사용하도록 수정했습니다.

## 📸 Before & After

**Before:**
- 50개의 메시지가 필터링되어도 → "12건" 표시 (현재 페이지의 메시지 개수)

**After:**
- 50개의 메시지가 필터링되면 → "50건" 표시 (전체 필터링된 메시지 개수)

## ✅ Testing
- [x] UserHistory 페이지 정상 렌더링 확인
- [x] 메시지 개수가 12개 이상일 때 전체 개수가 정확하게 표시되는지 확인
- [x] 필터링 적용 시 필터링된 전체 개수가 표시되는지 확인
- [x] 페이지 이동 시에도 전체 개수가 유지되는지 확인

## 📋 Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] UI/UX improvement

## 🏷️ Labels
- `bug`
- `ui/ux`
- `user`
- `pagination`
